### PR TITLE
Fixed case where shell did not update when dependencies changed

### DIFF
--- a/hello_rails/.envrc
+++ b/hello_rails/.envrc
@@ -151,4 +151,4 @@ validate_version() {
 	return 1
 }
 
-use_nix -s shell.nix -w ../nixpkgs-version.json
+use_nix -s shell.nix -w ../nixpkgs-version.json -w gemset.nix

--- a/panel/.envrc
+++ b/panel/.envrc
@@ -151,4 +151,4 @@ validate_version() {
 	return 1
 }
 
-use_nix -s shell.nix -w ../nixpkgs-version.json
+use_nix -s shell.nix -w ../nixpkgs-version.json -w gemset.nix


### PR DESCRIPTION
Rails project now also depend on the contents of gemsets.nix for calculating when to update the environment.