### PR TITLE
Fixed an issue where you could only submit a single change for a row.

### DIFF
--- a/panel/app/controllers/changes_controller.rb
+++ b/panel/app/controllers/changes_controller.rb
@@ -43,7 +43,7 @@ class ChangesController < ApplicationController
     if(row != nil)
       # Been changed before, check for unexecuted changes.
       changes = row.modifications;
-      if( changes == nil)
+      if( changes == nil || !changes.any?)
         # Insert new change here, row already exists
         new_change = row.modifications.create!( user_id: current_user.id, old_value: @data.to_json, new_value: new_val.to_json)
         #micro_put_change(params[:mid],new_change.id)


### PR DESCRIPTION
just a minor bug fix.

Upon adding the first change for a row, if you delete that change, it does not change the result of a query back to nil, instead it returns an empty array.

now the conditional statement checks for an empty array, and nil.