### PR TITLE
Fix username display bug and hide delete button

### DIFF
--- a/panel/app/controllers/changes_controller.rb
+++ b/panel/app/controllers/changes_controller.rb
@@ -23,10 +23,10 @@ class ChangesController < ApplicationController
       # Get same data but for executed table
       # Get metadata for each executed
       @metadataEx = []
-      @users = []
+      @usersEx = []
       @executed.each do |ex|
         @metadataEx.push(ex.row_entry)
-        @users.push(User.find(ex.user_id).username)
+        @usersEx.push(User.find(ex.user_id).username)
       end
 
       # Find microservice for each executed

--- a/panel/app/views/changes/index.html.erb
+++ b/panel/app/views/changes/index.html.erb
@@ -98,9 +98,12 @@
                                     </td>
                                 <% end %>
                                 <% if checkRole >= 3 %>
-                                    <td><%= link_to "Delete", change_path(change.id),
-                                                    class: "btn btn-danger",
-                                                    method: :delete %>
+                                    <td>
+                                        <% unless change.id.in? @changes_in_use %>
+                                            <%= link_to "Delete", change_path(change.id),
+                                                        class: "btn btn-danger",
+                                                        method: :delete %>
+                                        <% end %>
                                     </td>
                                 <% end %>
                             </tr>
@@ -149,7 +152,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                <% @executed.zip(@metadataEx, @microserviceEx, @users).each do |x, cmd, microservice, user| %>
+                <% @executed.zip(@metadataEx, @microserviceEx, @usersEx).each do |x, cmd, microservice, user| %>
                 <tr>
                     <!-- <td><%= x.id %></td> -->
                     <td><%= microservice.name %></td>

--- a/panel/app/views/microservices/_microservice_tile.html.erb
+++ b/panel/app/views/microservices/_microservice_tile.html.erb
@@ -5,9 +5,9 @@
         <% name.split(/\s|'|,|_/).each {|n| microservice.push(n.capitalize())} %>
       <b><%= microservice.join(" ") %></b>
     </div>
-<% end %>
     <ul class="list-group list-group-flush">
       <li class="list-group-item">Changes pending: <%=changes%></li>
     </ul>
+<% end %>
 </div>
 


### PR DESCRIPTION
Was using the same variable to get the usernames for both
queued and executed changes. Also added the check to hide the
delete button for changes that are part of a transaction.